### PR TITLE
Ensure that redis keys are in allocated in same hash slot[1]

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,11 +16,11 @@ class RedisCacheFunction {
     this.args = args
     this.EXEC_ID = Date.now() + ':' + Math.random().toString(36)
     const HASH = this.HASH = this.createHash(args)
-    this.VALUE = `${HASH}:value`
-    this.RUNNING = `${HASH}:running`
-    this.ERROR = `${HASH}:error`
-    this.PATTERN = `${HASH}:*`
-    this.PRECACHE = `${HASH}:precaching`
+    this.VALUE = `{${HASH}}:value`
+    this.RUNNING = `{${HASH}}:running`
+    this.ERROR = `{${HASH}}:error`
+    this.PATTERN = `{${HASH}}:*`
+    this.PRECACHE = `{${HASH}}:precaching`
   }
 
   // execute the logic


### PR DESCRIPTION
[1]: https://redis.io/topics/cluster-spec#keys-hash-tags